### PR TITLE
updated setup guide and settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,20 @@ pip install -r requirements.txt
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 
+SECRET_KEY = '' 
+
 DBPASSL = ''
 DBHOSTL = ''
 DBNAMEL = ''
 DBUSERL = ''
+DBPORTL = ''
+
+TIME_ZONE = ''
+
+CSRF_TRUSTED_ORIGINS = ''
+CORS_ALLOWED_ORIGINS = ''
+
+CELERY_BROKER_URL = ''
 ```
 
 5. Create a PostgreSQL database and connect it by entering credentials in .env file, once connected run the migrate command
@@ -91,7 +101,7 @@ http://127.0.0.1:8000
 7. You can create a superuser executing the following commands
 
 ```CMD
-python manage.py createsuperuer
+python manage.py createsuperuser
 ```
 
 A prompt will appear asking for email followed by password.

--- a/bulkmailer/settings.py
+++ b/bulkmailer/settings.py
@@ -175,10 +175,7 @@ EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 
-CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "localhost:3000").split(
-    ","
-)
-
+CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(",")
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(days=1),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
@@ -221,6 +218,4 @@ CELERY_RESULT_BACKEND = "django-db"
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 
 
-CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "localhost:3000").split(
-    ","
-)
+CORS_ALLOWED_ORIGINS = os.environ.get("CORS_ALLOWED_ORIGINS", "").split(",")


### PR DESCRIPTION
updated the setup guide given in the "README.md" file for `.env file` as per the new refactor #12 .

In settings.py file, we can directly read these values from `os.environ` ,  Removed the split(",") part in the `CORS_ALLOWED_ORIGINS` and `CSRF_TRUSTED_ORIGINS` assignments.







